### PR TITLE
Update readme + fix macos workflow

### DIFF
--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -80,7 +80,15 @@ jobs:
     steps:
       - uses: r-hub/actions/checkout@v1
         with:
-          submodules: 'true'      
+          submodules: 'true'
+      - name: Install libgit2 on macOS
+        if: ${{ matrix.config.name == 'macos' }}
+      # as of 09/2024: use 1.7 until newer git2r is released; see
+      # https://github.com/ropensci/git2r/issues/467 
+        run: |
+          brew install libgit2@1.7
+          brew link libgit2@1.7
+        shell: bash
       - uses: r-hub/actions/setup-r@v1
         with:
           job-config: ${{ matrix.config.job-config }}

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ to serialize and deserialize a user-defined `struct` using raw vectors:
 
 #include <cereal/archives/binary.hpp>
 
-[[cpp11::linking_to("Rcereal")]]
 struct MyClass
 {
     int x, y, z;
@@ -79,6 +78,7 @@ struct MyClass
     }
 };
 
+[[cpp11::linking_to("Rcereal")]]
 [[cpp11::register]]
 cpp11::raws serialize_myclass(int x = 1, int y = 2, int z = 3) {
     MyClass my_instance { x, y, z };
@@ -179,6 +179,8 @@ Rcpp::sourceCpp("path/to/example.cpp")
 raw_vector <- serialize_myclass(1, 2, 4)
 deserialize_myclass(raw_vector)
 ```
+
+[rcpp_cran]: https://cran.r-project.org/package=Rcpp
 
 
 ## Troubleshooting

--- a/configure
+++ b/configure
@@ -1,4 +1,14 @@
 #! /bin/sh
 
 # remove the pragma that suppresses diagnostics
-sed -i 's|^#pragma|// #pragma|' inst/include/cereal/external/base64.hpp
+# OS-specific sed command, see: https://stackoverflow.com/a/4247319/7050789
+OS="`uname`"
+case $OS in
+  'Darwin') 
+    sed -i '' -e 's|^#pragma|// #pragma|' 'inst/include/cereal/external/base64.hpp'
+    ;;
+  *)
+    sed -i -e 's|^#pragma|// #pragma|' 'inst/include/cereal/external/base64.hpp'
+    ;;
+esac
+

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -51,7 +51,6 @@ to serialize and deserialize a user-defined `struct` using raw vectors:
 
 #include <cereal/archives/binary.hpp>
 
-[[cpp11::linking_to("Rcereal")]]
 struct MyClass
 {
     int x, y, z;
@@ -63,6 +62,7 @@ struct MyClass
     }
 };
 
+[[cpp11::linking_to("Rcereal")]]
 [[cpp11::register]]
 cpp11::raws serialize_myclass(int x = 1, int y = 2, int z = 3) {
     MyClass my_instance { x, y, z };


### PR DESCRIPTION
Small changes to get the workflow passing.

Also fixed the examples for cpp11 in the README + vignette (attribute in the wrong place) and fixed a missing link in the README. 

NOTE: I've used homebrew `libgit2@1.7` as opposed to plain `libgit2` - which is 1.8. This is to get around the issue: https://github.com/ropensci/git2r/issues/467. I suspect that future releases of `git2r` will be compatible with 1.8, but for now, might as well use 1.7 in the workflow.